### PR TITLE
Change snmp oid parameter when prepare callback for different mappings

### DIFF
--- a/module/libs/checks.py
+++ b/module/libs/checks.py
@@ -155,14 +155,14 @@ def check_snmp(check, arguments, db_client, task_queue, result_queue):
                 mapping_task['data']["maxRepetitions"] = serv.get('max_rep_map',
                                                                   64)
                 mapping_task['data']['cbInfo'] = (callback_mapping_bulk,
-                                                  (serv['mapping'],
+                                                  (snmp_info.mapping,
                                                    check.result,
                                                    result))
             else:
                 # Add snmp request type
                 mapping_task['type'] = 'next'
                 mapping_task['data']['cbInfo'] = (callback_mapping_next,
-                                                  (serv['mapping'],
+                                                  (snmp_info.mapping,
                                                    check.result,
                                                    result))
             task_queue.put(mapping_task, block=False)


### PR DESCRIPTION
There is a problem when mappings with different OID needs to be done at the same time. It seems to be an issue with wrong parameters to the callback mapping function.